### PR TITLE
Add instruction for download SpaCy English model

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ This repo supports Linux and Python installation via Anaconda.
 
 1. Install [PyTorch](https://github.com/pytorch/pytorch) using [Anaconda](https://www.continuum.io/downloads)
 2. Install the requirements `pip install -r requirements`
-3. Run the preprocessing script for WN18RR, FB15k-237, YAGO3-10, UMLS, Kinship, and Nations: `sh preprocess.sh`
-3. You can now run the model
+3. Download the default English model used by [spaCy](https://github.com/explosion/spaCy), which is installed in the previous step `python -m spacy download en`
+4. Run the preprocessing script for WN18RR, FB15k-237, YAGO3-10, UMLS, Kinship, and Nations: `sh preprocess.sh`
+5. You can now run the model
 
 ## Running a model
 


### PR DESCRIPTION
This is to fix the following error: 

File "/home/xilin/Projects/ConvE/src/spodernet/spodernet/preprocessing/processors.py", line 20, in <module>
    nlp = spacy.load('en')
  File "/opt/conda/envs/pytorch-py3.6/lib/python3.6/site-packages/spacy/__init__.py", line 19, in load
    return util.load_model(name, **overrides)
  File "/opt/conda/envs/pytorch-py3.6/lib/python3.6/site-packages/spacy/util.py", line 120, in load_model
    raise IOError("Can't find model '%s'" % name)