### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repo supports Linux and Python installation via Anaconda.
 
 1. Install [PyTorch](https://github.com/pytorch/pytorch) using [Anaconda](https://www.continuum.io/downloads).
 2. Install the requirements `pip install -r requirements.txt`
-3. Download the default English model used by [spaCy](https://github.com/explosion/spaCy), which is installed in the previous step `python -m spacy download en`
+3. Download the default English model used by [spaCy](https://github.com/explosion/spaCy), which is installed in the previous step `python -m spacy download en_core_web_sm`
 4. Run the preprocessing script for WN18RR, FB15k-237, YAGO3-10, UMLS, Kinship, and Nations: `sh preprocess.sh`
 5. You can now run the model
 


### PR DESCRIPTION
en was depreceated when i ran the code, en_core_web_sm was recommended instead. (accompaniying request in spodernet/spodernet/preprocessing/processors.py on line 20)

Or Additionally specify Spacy version, that uses "en" 

In addition the requirements.txt often does not work smoothly, installing the two other repositories manually are far easier.

"pip install -e git+https://github.com/TimDettmers/spodernet.git@master#egg=spodernet pip install -e git+https://github.com/TimDettmers/bashmagic.git@master#egg=bashmagic"